### PR TITLE
refactor(source.js): Replace info.format.filename `pipe:0` with basen…

### DIFF
--- a/source.js
+++ b/source.js
@@ -222,6 +222,9 @@ class Source extends Resource {
       this.active()
       ffmpeg(stream).ffprobe((err, info) => {
         this.inactive()
+        info.format.filename = info.format.filename === 'pipe:0' ?
+          path.basename(this.uri) :
+          info.format.filename
         callback(err, info)
       })
     })


### PR DESCRIPTION
…ame of source URI; this is the "filename" when ffprobe encounters a piped file rather than a filepath