### PR TITLE
Fix track API

### DIFF
--- a/example/language/index.js
+++ b/example/language/index.js
@@ -11,6 +11,7 @@ console.log('Looking for romance languages...', romanceLanguages)
 source.open((err) => {
   const romanceSubs = []
   function onprobe(err, data) {
+    const batch = new Batch()
     for (const stream of data.streams) {
       const language = stream.tags.language
       console.log(stream.index,
@@ -18,10 +19,16 @@ source.open((err) => {
         romanceLanguages.includes(stream.tags.language)
       )
       if (romanceLanguages.includes(language)) {
-        romanceSubs.push(SubtitleTrack.from(source, stream.index))
+        const track = SubtitleTrack.from(source, stream.index)
+        batch.push((next) => track.ready(next))
+        romanceSubs.push(track)
       }
     }
-    console.log(romanceSubs)
+
+    batch.end((err) => {
+      console.log('romance subtitles on tracks %s', romanceSubs.map((track) => track.streamIndex))
+      //console.log(romanceSubs)
+    })
   }
 
   source.probe(onprobe)

--- a/track/audio.js
+++ b/track/audio.js
@@ -45,15 +45,6 @@ class AudioTrack extends Track {
   }
 
   /**
-   * `AudioTrack` class constructor.
-   * @param {Source} source
-   * @param {?(Object)} opts
-   */
-  constructor(source, opts) {
-    super(source, DEFAULT_STREAM_INDEX, opts)
-  }
-
-  /**
    * The number of channels in the track's source stream.
    * @accessor
    * @type {?(Number)}

--- a/track/subtitle.js
+++ b/track/subtitle.js
@@ -43,15 +43,6 @@ class SubtitleTrack extends Track {
   static get STREAM_TYPE() {
     return STREAM_TYPE
   }
-
-  /**
-   * `SubtitleTrack` class constructor.
-   * @param {Source} source
-   * @param {?(Object)} opts
-   */
-  constructor(source, opts) {
-    super(source, DEFAULT_STREAM_INDEX, opts)
-  }
 }
 
 /**

--- a/track/track.js
+++ b/track/track.js
@@ -32,11 +32,15 @@ class Track extends Resource {
    * URI string.
    * @static
    * @param {Source|String} source
-   * @param {?(Object)} opts
+   * @param {?(Object|Number)} opts
    * @param {?(Number)} opts.streamIndex
    * @return {Track}
    */
   static from(source, opts) {
+    if ('number' === typeof opts) {
+      opts = { streamIndex: opts }
+    }
+
     if (!opts || 'object' !== typeof opts) {
       opts = {}
     }
@@ -47,11 +51,7 @@ class Track extends Resource {
     // derive stream index from the class level property `DEFAULT_STREAM_INDEX`
     // where `opts.index` takes precedence and `0` is the default
     const { streamIndex = this.DEFAULT_STREAM_INDEX || 0 } = opts
-    return new this(
-      source,
-      'number' === typeof streamIndex ? streamIndex : 0,
-      opts
-    )
+    return new this(source, streamIndex, opts)
   }
 
   /**
@@ -82,17 +82,21 @@ class Track extends Resource {
    * @param {?(String)} opts.id
    */
   constructor(source, streamIndex, opts) {
+    super()
+
     if (!opts || 'object' !== typeof opts) {
       opts = {}
+    }
+
+    if ('number' !== typeof streamIndex || Number.isNaN(streamIndex)) {
+      streamIndex = this.constructor.DEFAULT_STREAM_INDEX
     }
 
     assert(source instanceof Source,
       'Expecting `source` to be an instance of `Source`.')
 
-    assert('number' === typeof streamIndex && streamIndex >= 0,
+    assert(streamIndex >= 0,
       'Expecting `streamIndex` to be >= 0. Got: ' + streamIndex)
-
-    super()
 
     this.id = opts.id || uuid()
     this.source = source

--- a/track/video.js
+++ b/track/video.js
@@ -48,15 +48,6 @@ class VideoTrack extends Track {
   }
 
   /**
-   * `VideoTrack` class constructor.
-   * @param {Source} source
-   * @param {?(Object)} opts
-   */
-  constructor(source, opts) {
-    super(source, DEFAULT_STREAM_INDEX, opts)
-  }
-
-  /**
    * Internal validation for a video track.
    * @param {Function}
    */


### PR DESCRIPTION
This pull request fixes how `streamIndex` is resolved for the track API. Currently, if you use any of the extending classes like `AudioTrack.from(source, stream.index)` where `stream.index` likely comes from `source.probe()` the `AudioTrack` constructor ignores the value and uses its `DEFAULT_STREAM_INDEX` value, for all instances. This is incorrect as a `Track` instance should allow its streamIndex to be configurable.

This pull request also prints out the `SubtitleTrack` `streamIndex` values for each language in the search for the language probe example.