### PR TITLE
refactor(package.json): Move `rimraf` from devDependencies to regular…

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "once": "^1.4.0",
     "pretty-ms": "^5.1.0",
     "pump": "^3.0.0",
+    "rimraf": "^3.0.0",
     "simple-get": "^3.1.0",
     "smpte-timecode": "^1.2.3",
     "streamx": "^2.5.0",
@@ -45,7 +46,6 @@
     "nyc": "^14.1.1",
     "pretty-bytes": "^5.3.0",
     "progress": "^2.0.3",
-    "rimraf": "^3.0.0",
     "tape": "^4.11.0"
   }
 }


### PR DESCRIPTION
This PR moves `rimraf` from the module's development dependencies and into the regular list of module dependencies.

Currently, requiring this module breaks when installing it it via `npm i little-media-box` because `rimraf` is not installed into `node_modules`.