### PR TITLE
Contextually set a Source.probe's FFprobe input type based upon URI

### DIFF
--- a/source.js
+++ b/source.js
@@ -223,7 +223,7 @@ class Source extends Resource {
 
 
       const { uri } = this
-      const stream = this.uri.includes('file://') ?
+      const stream = this.uri !== undefined && this.uri.includes('file://') ?
         this.uri : this.createReadStream(opts)
 
       this.active()

--- a/source.js
+++ b/source.js
@@ -220,8 +220,11 @@ class Source extends Resource {
 
     this.ready((err) => {
       if (err) { return callback(err) }
+
+
       const { uri } = this
-      const stream = this.createReadStream(opts)
+      const stream = this.uri.includes('file://') ?
+        this.uri : this.createReadStream(opts)
 
       this.active()
       ffmpeg(stream).ffprobe((err, info) => {

--- a/source.js
+++ b/source.js
@@ -223,7 +223,7 @@ class Source extends Resource {
 
 
       const { uri } = this
-      const stream = this.uri !== undefined && this.uri.includes('file://') ?
+      const stream = this.uri !== null && this.uri.includes('file://') ?
         this.uri : this.createReadStream(opts)
 
       this.active()


### PR DESCRIPTION
This PR introduces code in `Source.probe`, which sets the FFprobe input as a file path string when the Source.uri begins with `file://`, and for all other types of URIs, sets the input as a ReadableStream.

Address the concerns raised in #13 - mainly, that sending Sources with a file:// URI degrades the potential data quality FFprobe can return when probing for container-level metadata.